### PR TITLE
Resolve symlinks

### DIFF
--- a/byu_pytest_utils/__init__.py
+++ b/byu_pytest_utils/__init__.py
@@ -25,7 +25,7 @@ def _get_caller_file() -> Path:
     index = 0
     while s[index].filename == __file__:
         index += 1
-    return Path(s[index].filename).absolute()
+    return Path(s[index].filename).resolve()
 
 
 # We want `this_folder` to be the folder of the caller


### PR DESCRIPTION
Some students pytest's will fail because of the library not properly resolving the paths to the test_files directory. This should ensure that any symlinks are followed fixing errors caused by special cases like when stored in iCloud or OneDrive.